### PR TITLE
benchmark lazy

### DIFF
--- a/fibonacci_even_sum/marocchino/lib/fibonacci_even_sum.rb
+++ b/fibonacci_even_sum/marocchino/lib/fibonacci_even_sum.rb
@@ -5,8 +5,16 @@ module FibonacciEvenSum
     fibo.take_while { |n| n < number }
   end
 
+  def lazy_take_less_than(number)
+    fibo.lazy.take_while { |n| n < number }
+  end
+
   def even_sum(number)
     take_less_than(number).select(&:even?).reduce(:+)
+  end
+
+  def lazy_even_sum(number)
+    lazy_take_less_than(number).select(&:even?).reduce(:+)
   end
 
   def fibo

--- a/fibonacci_even_sum/marocchino/test/test_fibonacci_benchmark.rb
+++ b/fibonacci_even_sum/marocchino/test/test_fibonacci_benchmark.rb
@@ -1,0 +1,18 @@
+require 'minitest_helper'
+if ENV['BENCH']
+  require 'minitest/benchmark'
+
+  class TestFibonacciBenchmark < Minitest::Benchmark
+    def bench_even_sum
+      assert_performance_constant 0.99 do
+        FibonacciEvenSum.even_sum(4_000_000)
+      end
+    end
+
+    def bench_lazy_even_sum
+      assert_performance_constant 0.99 do
+        FibonacciEvenSum.lazy_even_sum(4_000_000)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[기영님 리플](https://www.facebook.com/groups/rubykr/permalink/986068744739153/?comment_id=986136321399062&offset=0&total_comments=7&comment_tracking=%7B%22tn%22%3A%22R1%22%7D)보고 lazy 붙이면 빠른가 싶어서 돌려봤어요.

```
$ env BENCH=1 rake
Run options: --seed 23790

# Running:

..bench_even_sum	 0.000070	 0.000053	 0.000048	 0.000044	 0.000047
.bench_lazy_even_sum	 0.000104	 0.000085	 0.000089	 0.000075	 0.000104
```